### PR TITLE
create log file directories when installing app

### DIFF
--- a/scripts/scripts/postinstall
+++ b/scripts/scripts/postinstall
@@ -15,6 +15,10 @@ rm -f "/Library/LaunchDaemons/$PLIST_FILE";
 cp "$PLIST_FILE" "/Library/LaunchDaemons/$PLIST_FILE";
 /bin/launchctl load -w "/Library/LaunchDaemons/$PLIST_FILE";
 
+# Create log directory
+mkdir -p /Library/Logs/Pahkat
+su "$USER" -c "mkdir -p ~/Library/Logs/MacDivvun"
+
 if [[ ! $COMMAND_LINE_INSTALL ]]; then
   for i in $(seq 1 5); do su "$USER" -c "open /Applications/Divvun\ Manager.app" && s=0 && break || s=$? && sleep 1; done; (exit $s)
 fi


### PR DESCRIPTION
Pahkat log file directory was only accessible as root user and could not be exported by the app.
MacDivvun log file was never created because the log directory was never created.

Both is now fixed and Pahkat and MacDivvun logs should now be part of the zip file generated by the app via the help menu.